### PR TITLE
fix: instrumenteditor starting expansion state

### DIFF
--- a/tracker/gioui/instrumenteditor.go
+++ b/tracker/gioui/instrumenteditor.go
@@ -132,7 +132,7 @@ func (ie *InstrumentEditor) Layout(gtx C, t *Tracker) D {
 func (ie *InstrumentEditor) layoutInstrumentHeader(gtx C, t *Tracker) D {
 	header := func(gtx C) D {
 		collapseIcon := icons.NavigationExpandLess
-		if ie.commentExpanded {
+		if !ie.commentExpanded {
 			collapseIcon = icons.NavigationExpandMore
 		}
 


### PR DESCRIPTION
The instrument editor's comment expansion button was up, which is normally used to indicate the option to close, but on clicking the comment box is actually expanded.  
The toggling mechanisms are left unchanged, just the initial state is modified by changing the condition for re-setting the `collapseIcon` variable in the `layoutInstrumentHeader` method.  