### PR TITLE
fix(sointu): Changed go version in `go.mod` to enable builds with dev toolchains

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vsariola/sointu
 
-go 1.23
+go 1.23.0
 
 require (
 	gioui.org v0.7.1


### PR DESCRIPTION
This fixes a problem with the go toolchain version detailed here: https://github.com/golang/go/issues/62278, using the solution proposed in https://github.com/golang/go/issues/62278#issuecomment-1698829945.

The symptom of the problem is
```
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```