### PR TITLE
fix: allow sointu-play to use go_synth, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Numeric updown widget calculated dp-to-px conversion incorrectly, resulting in
   wrong scaling ([#150][i150])
 - Empty patch should not crash the native synth ([#148][i148])
+- sointu-play does not default to the native synth yet, choose via `-tags=native`
 
 ### Changed
 - The keyboard shortcuts are now again closer to what they were old trackers

--- a/cmd/sointu-play/main.go
+++ b/cmd/sointu-play/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/vsariola/sointu/cmd"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,7 +15,6 @@ import (
 	"github.com/vsariola/sointu"
 	"github.com/vsariola/sointu/oto"
 	"github.com/vsariola/sointu/version"
-	"github.com/vsariola/sointu/vm/compiler/bridge"
 )
 
 func main() {
@@ -93,7 +93,7 @@ func main() {
 				return fmt.Errorf("the song could not be parsed as .json (%v) or .yml (%v)", errJSON, errYaml)
 			}
 		}
-		buffer, err := sointu.Play(bridge.NativeSynther{}, song, nil) // render the song to calculate its length
+		buffer, err := sointu.Play(cmd.MainSynther, song, nil) // render the song to calculate its length
 		if err != nil {
 			return fmt.Errorf("sointu.Play failed: %v", err)
 		}


### PR DESCRIPTION
This is just a minor thing I saw after you told me about sointu-play -- this one always used the Native synth for now. I figured it might make sense to use the same behaviour as sointu-track, e.g. with "-tags=native", use the Native Synth, without tags, use the Go synth.

This is obviously just a very simple offer. Did I miss something?