### PR TITLE
Highlight when a Parameter is controlled by a Send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Include version info in the binaries, as given be `git describe`. This version
   info is shown as a label in the tracker and can be checked with `-v` flag in
   the command line tools.
+- If a parameter is controlled by a `send`, the slider is now colored differently
+  and there's a tooltip over the value to see where it comes from and its amount
 
 ### Fixed
 - We try to honor the MIDI event time stamps, so that the timing between MIDI

--- a/patch.go
+++ b/patch.go
@@ -464,3 +464,22 @@ func (p Patch) FindUnit(id int) (instrIndex int, unitIndex int, err error) {
 	}
 	return 0, 0, fmt.Errorf("could not find a unit with id %v", id)
 }
+
+func FindParamForModulationPort(unitName string, index int) *UnitParameter {
+	// qm210: couldn't see a function yet that matches the parameter index to the modulateable param.
+	// Not sure whether *UnitParameters is good here, would this make them mutable?
+	unitType, ok := UnitTypes[unitName]
+	if !ok {
+		return nil
+	}
+	for _, param := range unitType {
+		if index == 0 {
+			return &param
+		}
+		if param.CanModulate {
+			index--
+		}
+	}
+	// index outside range
+	return nil
+}

--- a/patch.go
+++ b/patch.go
@@ -465,21 +465,19 @@ func (p Patch) FindUnit(id int) (instrIndex int, unitIndex int, err error) {
 	return 0, 0, fmt.Errorf("could not find a unit with id %v", id)
 }
 
-func FindParamForModulationPort(unitName string, index int) *UnitParameter {
-	// qm210: couldn't see a function yet that matches the parameter index to the modulateable param.
-	// Not sure whether *UnitParameters is good here, would this make them mutable?
+func FindParamForModulationPort(unitName string, index int) (UnitParameter, bool) {
 	unitType, ok := UnitTypes[unitName]
 	if !ok {
-		return nil
+		return UnitParameter{}, false
 	}
 	for _, param := range unitType {
+		if !param.CanModulate {
+			continue
+		}
 		if index == 0 {
-			return &param
+			return param, true
 		}
-		if param.CanModulate {
-			index--
-		}
+		index--
 	}
-	// index outside range
-	return nil
+	return UnitParameter{}, false
 }

--- a/song.go
+++ b/song.go
@@ -2,7 +2,6 @@ package sointu
 
 import (
 	"errors"
-	"iter"
 )
 
 type (
@@ -335,33 +334,4 @@ func TotalVoices[T any, S ~[]T, P NumVoicerPointer[T]](slice S) (ret int) {
 		ret += (P)(&e).GetNumVoices()
 	}
 	return
-}
-
-func (s *Song) InstrumentForTrack(trackIndex int) (int, bool) {
-	voiceIndex := s.Score.FirstVoiceForTrack(trackIndex)
-	instrument, err := s.Patch.InstrumentForVoice(voiceIndex)
-	return instrument, err == nil
-}
-
-func (s *Song) AllTracksWithSameInstrument(trackIndex int) iter.Seq[int] {
-	return func(yield func(int) bool) {
-
-		currentInstrument, currentExists := s.InstrumentForTrack(trackIndex)
-		if !currentExists {
-			return
-		}
-
-		for i := 0; i < len(s.Score.Tracks); i++ {
-			instrument, exists := s.InstrumentForTrack(i)
-			if !exists {
-				return
-			}
-			if instrument != currentInstrument {
-				continue
-			}
-			if !yield(i) {
-				return
-			}
-		}
-	}
 }

--- a/tracker/action.go
+++ b/tracker/action.go
@@ -141,7 +141,7 @@ func (m *Model) SplitInstrument() Action {
 
 func (m *Model) AddUnit(before bool) Action {
 	return Allow(func() {
-		defer (*Model)(m).change("AddUnitAction", PatchChange, MajorChange)()
+		defer m.change("AddUnitAction", PatchChange, MajorChange)()
 		if len(m.d.Song.Patch) == 0 { // no instruments, add one
 			instr := sointu.Instrument{NumVoices: 1}
 			instr.Units = make([]sointu.Unit, 0, 1)
@@ -159,9 +159,16 @@ func (m *Model) AddUnit(before bool) Action {
 		m.d.UnitIndex2 = m.d.UnitIndex
 		copy(newUnits, instr.Units[:m.d.UnitIndex])
 		copy(newUnits[m.d.UnitIndex+1:], instr.Units[m.d.UnitIndex:])
-		(*Model)(m).assignUnitIDs(newUnits[m.d.UnitIndex : m.d.UnitIndex+1])
+		m.assignUnitIDs(newUnits[m.d.UnitIndex : m.d.UnitIndex+1])
 		m.d.Song.Patch[m.d.InstrIndex].Units = newUnits
 		m.d.ParamIndex = 0
+	})
+}
+
+func (m *Model) AddUnitAndThen(callback func()) Action {
+	return Allow(func() {
+		m.AddUnit(false).Do()
+		callback()
 	})
 }
 

--- a/tracker/derived.go
+++ b/tracker/derived.go
@@ -1,0 +1,235 @@
+package tracker
+
+import (
+	"github.com/vsariola/sointu"
+	"iter"
+	"slices"
+)
+
+/*
+	from modelData we can derive useful information that can be cached for performance
+	or easy access, because of nested iterations over the score or patch data.
+	i.e. this needs to update when the model changes, and only then.
+*/
+
+type (
+	derivedForUnit struct {
+		unit       *sointu.Unit
+		instrument *sointu.Instrument
+		sends      []*sointu.Unit
+	}
+
+	derivedForTrack struct {
+		instrumentRange          []int
+		tracksWithSameInstrument []int
+		title                    string
+	}
+
+	derivedModelData struct {
+		// map unit by ID
+		forUnit map[int]derivedForUnit
+		// map track by index
+		forTrack map[int]derivedForTrack
+	}
+)
+
+// public access functions
+
+func (m *Model) forUnitById(id int) *derivedForUnit {
+	forUnit, ok := m.derived.forUnit[id]
+	if !ok {
+		return nil
+	}
+	return &forUnit
+}
+
+func (m *Model) InstrumentForUnit(id int) *sointu.Instrument {
+	fu := m.forUnitById(id)
+	if fu == nil {
+		return nil
+	}
+	return fu.instrument
+}
+
+func (m *Model) UnitById(id int) *sointu.Unit {
+	fu := m.forUnitById(id)
+	if fu == nil {
+		return nil
+	}
+	return fu.unit
+}
+
+func (m *Model) SendTargetsForUnit(id int) []*sointu.Unit {
+	fu := m.forUnitById(id)
+	if fu == nil {
+		return nil
+	}
+	return fu.sends
+}
+
+func (m *Model) forTrackByIndex(index int) *derivedForTrack {
+	forTrack, ok := m.derived.forTrack[index]
+	if !ok {
+		return nil
+	}
+	return &forTrack
+}
+
+func (m *Model) TrackTitle(index int) string {
+	ft := m.forTrackByIndex(index)
+	if ft == nil {
+		return ""
+	}
+	return ft.title
+}
+
+// public getters with further model information
+
+func (m *Model) TracksWithSameInstrumentAsCurrent() []int {
+	currentTrack := m.d.Cursor.Track
+	return m.derived.forTrack[currentTrack].tracksWithSameInstrument
+}
+
+func (m *Model) CountNextTracksForCurrentInstrument() int {
+	currentTrack := m.d.Cursor.Track
+	count := 0
+	for t := range m.TracksWithSameInstrumentAsCurrent() {
+		if t > currentTrack {
+			count++
+		}
+	}
+	return count
+}
+
+// init / update methods
+
+func (m *Model) initDerivedData() {
+	m.derived = derivedModelData{
+		forUnit:  make(map[int]derivedForUnit),
+		forTrack: make(map[int]derivedForTrack),
+	}
+	m.updateDerivedScoreData()
+	m.updateDerivedPatchData()
+}
+
+func (m *Model) updateDerivedScoreData() {
+	for index, _ := range m.d.Song.Score.Tracks {
+		firstInstr, lastInstr, _ := m.instrumentRangeFor(index)
+		m.derived.forTrack[index] = derivedForTrack{
+			instrumentRange:          []int{firstInstr, lastInstr},
+			tracksWithSameInstrument: slices.Collect(m.tracksWithSameInstrument(index)),
+			title:                    m.buildTrackTitle(index),
+		}
+	}
+}
+
+func (m *Model) updateDerivedPatchData() {
+	for _, instr := range m.d.Song.Patch {
+		for _, unit := range instr.Units {
+			m.derived.forUnit[unit.ID] = derivedForUnit{
+				unit:       &unit,
+				instrument: &instr,
+				sends:      slices.Collect(m.collectSendsTo(unit)),
+			}
+		}
+	}
+}
+
+// internals...
+
+func (m *Model) collectSendsTo(unit sointu.Unit) iter.Seq[*sointu.Unit] {
+	return func(yield func(*sointu.Unit) bool) {
+		for _, instr := range m.d.Song.Patch {
+			for _, u := range instr.Units {
+				if u.Type != "send" {
+					continue
+				}
+				targetId, ok := u.Parameters["target"]
+				if !ok || targetId != unit.ID {
+					continue
+				}
+				if !yield(&u) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (m *Model) instrumentRangeFor(trackIndex int) (int, int, error) {
+	track := m.d.Song.Score.Tracks[trackIndex]
+	firstVoice := m.d.Song.Score.FirstVoiceForTrack(trackIndex)
+	lastVoice := firstVoice + track.NumVoices - 1
+	firstIndex, err1 := m.d.Song.Patch.InstrumentForVoice(firstVoice)
+	if err1 != nil {
+		return trackIndex, trackIndex, err1
+	}
+	lastIndex, err2 := m.d.Song.Patch.InstrumentForVoice(lastVoice)
+	if err2 != nil {
+		return trackIndex, trackIndex, err2
+	}
+	return firstIndex, lastIndex, nil
+}
+
+func (m *Model) buildTrackTitle(x int) (title string) {
+	title = "?"
+	if x < 0 || x >= len(m.d.Song.Score.Tracks) {
+		return
+	}
+	firstIndex, lastIndex, err := m.instrumentRangeFor(x)
+	if err != nil {
+		return
+	}
+	switch diff := lastIndex - firstIndex; diff {
+	case 0:
+		title = m.d.Song.Patch[firstIndex].Name
+	default:
+		n1 := m.d.Song.Patch[firstIndex].Name
+		n2 := m.d.Song.Patch[firstIndex+1].Name
+		if len(n1) > 0 {
+			n1 = string(n1[0])
+		} else {
+			n1 = "?"
+		}
+		if len(n2) > 0 {
+			n2 = string(n2[0])
+		} else {
+			n2 = "?"
+		}
+		if diff > 1 {
+			title = n1 + "/" + n2 + "..."
+		} else {
+			title = n1 + "/" + n2
+		}
+	}
+	return
+}
+
+func (m *Model) instrumentForTrack(trackIndex int) (int, bool) {
+	voiceIndex := m.d.Song.Score.FirstVoiceForTrack(trackIndex)
+	instrument, err := m.d.Song.Patch.InstrumentForVoice(voiceIndex)
+	return instrument, err == nil
+}
+
+func (m *Model) tracksWithSameInstrument(trackIndex int) iter.Seq[int] {
+	return func(yield func(int) bool) {
+
+		currentInstrument, currentExists := m.instrumentForTrack(trackIndex)
+		if !currentExists {
+			return
+		}
+
+		for i := 0; i < len(m.d.Song.Score.Tracks); i++ {
+			instrument, exists := m.instrumentForTrack(i)
+			if !exists {
+				return
+			}
+			if instrument != currentInstrument {
+				continue
+			}
+			if !yield(i) {
+				return
+			}
+		}
+	}
+}

--- a/tracker/gioui/editor.go
+++ b/tracker/gioui/editor.go
@@ -13,8 +13,9 @@ type (
 	// application while editing (particularly: to prevent triggering notes
 	// while editing).
 	Editor struct {
-		Editor  widget.Editor
-		filters []event.Filter
+		Editor       widget.Editor
+		filters      []event.Filter
+		requestFocus bool
 	}
 
 	EditorStyle material.EditorStyle
@@ -74,6 +75,10 @@ func (e *Editor) Cancelled(gtx C) bool {
 		}
 	}
 	return false
+}
+
+func (e *Editor) Focus() {
+	e.requestFocus = true
 }
 
 func (e *EditorStyle) Layout(gtx C) D {

--- a/tracker/gioui/instrument_editor.go
+++ b/tracker/gioui/instrument_editor.go
@@ -72,7 +72,6 @@ func NewInstrumentEditor(model *tracker.Model) *InstrumentEditor {
 		copyInstrumentBtn:   new(TipClickable),
 		saveInstrumentBtn:   new(TipClickable),
 		loadInstrumentBtn:   new(TipClickable),
-		addUnitBtn:          NewActionClickable(model.AddUnit(false)),
 		commentExpandBtn:    NewBoolClickable(model.CommentExpanded().Bool()),
 		presetMenuBtn:       new(TipClickable),
 		soloBtn:             NewBoolClickable(model.Solo().Bool()),
@@ -91,6 +90,7 @@ func NewInstrumentEditor(model *tracker.Model) *InstrumentEditor {
 		ret.presetMenuItems = append(ret.presetMenuItems, MenuItem{Text: name, IconBytes: icons.ImageAudiotrack, Doer: model.LoadPreset(index)})
 		return true
 	})
+	ret.addUnitBtn = NewActionClickable(model.AddUnitAndThen(func() { ret.searchEditor.Focus() }))
 	ret.enlargeHint = makeHint("Enlarge", " (%s)", "InstrEnlargedToggle")
 	ret.shrinkHint = makeHint("Shrink", " (%s)", "InstrEnlargedToggle")
 	ret.addInstrumentHint = makeHint("Add\ninstrument", "\n(%s)", "AddInstrument")
@@ -382,6 +382,12 @@ func (ie *InstrumentEditor) layoutUnitList(gtx C, t *Tracker) D {
 		units[i] = item
 	}
 	count := min(ie.unitDragList.TrackerList.Count(), 256)
+
+	if ie.searchEditor.requestFocus {
+		// for now, only the searchEditor has its requestFocus flag
+		ie.searchEditor.requestFocus = false
+		gtx.Execute(key.FocusCmd{Tag: &ie.searchEditor.Editor})
+	}
 
 	element := func(gtx C, i int) D {
 		gtx.Constraints.Max.Y = gtx.Dp(20)

--- a/tracker/gioui/note_editor.go
+++ b/tracker/gioui/note_editor.go
@@ -293,7 +293,7 @@ func (te *NoteEditor) layoutTracks(gtx C, t *Tracker) D {
 		}
 		// draw the corresponding "fake cursors" for instrument-track-groups (for polyphony)
 		if hasTrackMidiIn {
-			for trackIndex := range t.Model.TracksWithSameInstrumentAsCurrent() {
+			for _, trackIndex := range t.Model.TracksWithSameInstrumentAsCurrent() {
 				if x == trackIndex && y == cursor.Y {
 					te.paintColumnCell(gtx, x, t, cursorNeighborForTrackMidiInColor)
 				}
@@ -310,7 +310,7 @@ func (te *NoteEditor) layoutTracks(gtx C, t *Tracker) D {
 			paint.ColorOp{Color: trackerPatMarker}.Add(gtx.Ops)
 			widget.Label{}.Layout(gtx, t.Theme.Shaper, trackerFont, trackerFontSize, patternIndexToString(s), op.CallOp{})
 		}
-		if row == 1 && t.Model.Notes().Unique(x, s) { // draw a * if the pattern is unique
+		if row == 1 && t.Model.PatternUnique(x, s) { // draw a * if the pattern is unique
 			paint.ColorOp{Color: mediumEmphasisTextColor}.Add(gtx.Ops)
 			widget.Label{}.Layout(gtx, t.Theme.Shaper, trackerFont, trackerFontSize, "*", op.CallOp{})
 		}

--- a/tracker/gioui/note_editor.go
+++ b/tracker/gioui/note_editor.go
@@ -220,12 +220,11 @@ func (te *NoteEditor) layoutTracks(gtx C, t *Tracker) D {
 	pxRowMarkWidth := gtx.Dp(trackRowMarkWidth)
 
 	colTitle := func(gtx C, i int) D {
-		h := gtx.Dp(unit.Dp(trackColTitleHeight))
-		title := ((*tracker.Order)(t.Model)).Title(i)
+		h := gtx.Dp(trackColTitleHeight)
 		gtx.Constraints = layout.Exact(image.Pt(pxWidth, h))
 		LabelStyle{
 			Alignment: layout.N,
-			Text:      title,
+			Text:      t.Model.TrackTitle(i),
 			FontSize:  unit.Sp(12),
 			Color:     mediumEmphasisTextColor,
 			Shaper:    t.Theme.Shaper,
@@ -294,7 +293,7 @@ func (te *NoteEditor) layoutTracks(gtx C, t *Tracker) D {
 		}
 		// draw the corresponding "fake cursors" for instrument-track-groups (for polyphony)
 		if hasTrackMidiIn {
-			for trackIndex := range ((*tracker.Order)(t.Model)).TrackIndicesForCurrentInstrument() {
+			for trackIndex := range t.Model.TracksWithSameInstrumentAsCurrent() {
 				if x == trackIndex && y == cursor.Y {
 					te.paintColumnCell(gtx, x, t, cursorNeighborForTrackMidiInColor)
 				}
@@ -414,7 +413,7 @@ func (te *NoteEditor) HandleMidiInput(t *Tracker) {
 		return
 	}
 	te.scrollTable.Table.SetCursor2(te.scrollTable.Table.Cursor())
-	remaining := (*tracker.Order)(t.Model).CountNextTracksForCurrentInstrument()
+	remaining := t.Model.CountNextTracksForCurrentInstrument()
 	for i, note := range t.MidiNotePlaying {
 		t.Model.Notes().Table().Set(note)
 		te.scrollTable.Table.MoveCursor(1, 0)

--- a/tracker/gioui/order_editor.go
+++ b/tracker/gioui/order_editor.go
@@ -68,8 +68,13 @@ func (oe *OrderEditor) Layout(gtx C, t *Tracker) D {
 		defer op.Offset(image.Pt(0, -2)).Push(gtx.Ops).Pop()
 		defer op.Affine(f32.Affine2D{}.Rotate(f32.Pt(0, 0), -90*math.Pi/180).Offset(f32.Point{X: 0, Y: float32(h)})).Push(gtx.Ops).Pop()
 		gtx.Constraints = layout.Exact(image.Pt(1e6, 1e6))
-		title := t.Model.Order().Title(i)
-		LabelStyle{Alignment: layout.NW, Text: title, FontSize: unit.Sp(12), Color: mediumEmphasisTextColor, Shaper: t.Theme.Shaper}.Layout(gtx)
+		LabelStyle{
+			Alignment: layout.NW,
+			Text:      t.Model.TrackTitle(i),
+			FontSize:  unit.Sp(12),
+			Color:     mediumEmphasisTextColor,
+			Shaper:    t.Theme.Shaper,
+		}.Layout(gtx)
 		return D{Size: image.Pt(gtx.Dp(patternCellWidth), h)}
 	}
 

--- a/tracker/gioui/theme.go
+++ b/tracker/gioui/theme.go
@@ -74,3 +74,4 @@ var warningColor = color.NRGBA{R: 251, G: 192, B: 45, A: 255}
 var dialogBgColor = color.NRGBA{R: 0, G: 0, B: 0, A: 224}
 
 var paramIsSendTargetColor = color.NRGBA{R: 120, G: 120, B: 210, A: 255}
+var paramValueInvalidColor = color.NRGBA{R: 120, G: 120, B: 120, A: 190}

--- a/tracker/gioui/theme.go
+++ b/tracker/gioui/theme.go
@@ -72,3 +72,5 @@ var scrollBarColor = color.NRGBA{R: 255, G: 255, B: 255, A: 32}
 var warningColor = color.NRGBA{R: 251, G: 192, B: 45, A: 255}
 
 var dialogBgColor = color.NRGBA{R: 0, G: 0, B: 0, A: 224}
+
+var paramIsSendTargetColor = color.NRGBA{R: 120, G: 120, B: 210, A: 255}

--- a/tracker/gioui/unit_editor.go
+++ b/tracker/gioui/unit_editor.go
@@ -340,7 +340,11 @@ func (p ParameterStyle) Layout(gtx C) D {
 					unitItems = make([]MenuItem, len(units))
 					for j, unit := range units {
 						id := unit.ID
-						unitItems[j].Text = fmt.Sprintf("%d: %s %s", j, unit.Type, unit.Comment)
+						text := unit.Type
+						if unit.Comment != "" {
+							text = fmt.Sprintf("%s \"%s\"", text, unit.Comment)
+						}
+						unitItems[j].Text = fmt.Sprintf("%d: %s", j, text)
 						unitItems[j].IconBytes = icons.NavigationChevronRight
 						unitItems[j].Doer = tracker.Allow(func() {
 							tracker.Int{IntData: p.w.Parameter}.Set(id)

--- a/tracker/params.go
+++ b/tracker/params.go
@@ -204,6 +204,10 @@ func (p NamedParameter) LargeStep() int {
 	return 16
 }
 
+func (p NamedParameter) Unit() sointu.Unit {
+	return *p.parameter.unit
+}
+
 // GmDlsEntryParameter
 
 func (p GmDlsEntryParameter) Name() string        { return "sample" }

--- a/tracker/player.go
+++ b/tracker/player.go
@@ -11,8 +11,8 @@ import (
 type (
 	// Player is the audio player for the tracker, run in a separate thread. It
 	// is controlled by messages from the model and MIDI messages via the
-	// context, typically from the VSTI host. The player sends messages to the
-	// model via the playerMessages channel. The model sends messages to the
+	// context, typically from the VSTI host. The player sendTargets messages to the
+	// model via the playerMessages channel. The model sendTargets messages to the
 	// player via the modelMessages channel.
 	Player struct {
 		synth       sointu.Synth           // the synth used to render audio
@@ -344,7 +344,7 @@ func (p *Player) compileOrUpdateSynth() {
 	}
 }
 
-// all sends from player are always non-blocking, to ensure that the player thread cannot end up in a dead-lock
+// all sendTargets from player are always non-blocking, to ensure that the player thread cannot end up in a dead-lock
 func (p *Player) send(message interface{}) {
 	trySend(p.broker.ToModel, MsgToModel{HasPanicPosLevels: true, Panic: p.synth == nil, SongPosition: p.songPos, VoiceLevels: p.voiceLevels, Data: message})
 }

--- a/tracker/presets.go
+++ b/tracker/presets.go
@@ -21,7 +21,7 @@ type (
 		LoopStart          int    // loop start offset in words
 		LoopLength         int    // loop length in words
 		SuggestedTranspose int    // suggested transpose in semitones, so that all samples play at same pitch
-		Name               string // sample name
+		Name               string // sample Name
 	}
 
 	InstrumentPresetYieldFunc func(index int, item string) (ok bool)

--- a/tracker/table.go
+++ b/tracker/table.go
@@ -576,13 +576,6 @@ func (m *Notes) LowNibble() bool {
 	return m.d.LowNibble
 }
 
-func (m *Notes) Unique(t, p int) bool {
-	if t < 0 || t >= len(m.cachePatternUseCount) || p < 0 || p >= len(m.cachePatternUseCount[t]) {
-		return false
-	}
-	return m.cachePatternUseCount[t][p] == 1
-}
-
 func (m *Notes) SetValue(p Point, val byte) {
 	defer m.change("SetValue", MinorChange)()
 	if p.Y < 0 || p.X < 0 || p.X >= len(m.d.Song.Score.Tracks) {

--- a/tracker/table.go
+++ b/tracker/table.go
@@ -1,7 +1,6 @@
 package tracker
 
 import (
-	"iter"
 	"math"
 
 	"github.com/vsariola/sointu"
@@ -365,71 +364,6 @@ func (m *Order) Value(p Point) int {
 func (m *Order) SetValue(p Point, val int) {
 	defer (*Model)(m).change("OrderElement.SetValue", ScoreChange, MinorChange)()
 	m.d.Song.Score.Tracks[p.X].Order.Set(p.Y, val)
-}
-
-func (e *Order) Title(x int) (title string) {
-	title = "?"
-	if x < 0 || x >= len(e.d.Song.Score.Tracks) {
-		return
-	}
-	firstIndex, lastIndex, err := e.instrumentListFor(x)
-	if err != nil {
-		return
-	}
-	switch diff := lastIndex - firstIndex; diff {
-	case 0:
-		title = e.d.Song.Patch[firstIndex].Name
-	default:
-		n1 := e.d.Song.Patch[firstIndex].Name
-		n2 := e.d.Song.Patch[firstIndex+1].Name
-		if len(n1) > 0 {
-			n1 = string(n1[0])
-		} else {
-			n1 = "?"
-		}
-		if len(n2) > 0 {
-			n2 = string(n2[0])
-		} else {
-			n2 = "?"
-		}
-		if diff > 1 {
-			title = n1 + "/" + n2 + "..."
-		} else {
-			title = n1 + "/" + n2
-		}
-	}
-	return
-}
-
-func (e *Order) instrumentListFor(trackIndex int) (int, int, error) {
-	track := e.d.Song.Score.Tracks[trackIndex]
-	firstVoice := e.d.Song.Score.FirstVoiceForTrack(trackIndex)
-	lastVoice := firstVoice + track.NumVoices - 1
-	firstIndex, err1 := e.d.Song.Patch.InstrumentForVoice(firstVoice)
-	if err1 != nil {
-		return trackIndex, trackIndex, err1
-	}
-	lastIndex, err2 := e.d.Song.Patch.InstrumentForVoice(lastVoice)
-	if err2 != nil {
-		return trackIndex, trackIndex, err2
-	}
-	return firstIndex, lastIndex, nil
-}
-
-func (e *Order) TrackIndicesForCurrentInstrument() iter.Seq[int] {
-	currentTrack := e.d.Cursor.Track
-	return e.d.Song.AllTracksWithSameInstrument(currentTrack)
-}
-
-func (e *Order) CountNextTracksForCurrentInstrument() int {
-	currentTrack := e.d.Cursor.Track
-	count := 0
-	for t := range e.TrackIndicesForCurrentInstrument() {
-		if t > currentTrack {
-			count++
-		}
-	}
-	return count
 }
 
 // NoteTable


### PR DESCRIPTION
Hey,

for debugging larger patches, or just generally knowing what's going on, I found it useful to display parameters that are also targets of some "send" somewhere in a different color. tooltip over the value tells you even more information

![image](https://github.com/user-attachments/assets/6d0877ae-46f7-4bed-916e-cac828cfbf54)

PS: because I had this on a branch where I was generally improving (IMO) user experience (i.e. my own), this also has a minor fix that when you press the "Add Unit", the searchEditor is instantly active (i.e. you can start writing the unit name without clicking, I hate unnecessary clicks); and a quick styling fix that puts the operator comment into "quotes" for clarity.


---

on that occasion, (but these are basics that I could also find out by reading the source code) -- what actually happens when e.g. I have a gain that is 80 and I send a value to it with amount 128? will it then go to 128, or somehow, larger? and when zending a 0, will it stay at 80 or go to 0?
