### PR TITLE
feat: input midi velocity into a separate track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Dragging mouse to select rectangles in the tables
 - The standalone tracker can open a MIDI port for receiving MIDI notes
   ([#166][i166])
-- The note editor has a button to allow entering notes by MIDI. Polyphony is
-  supported if there are tracks available. ([#170][i170])
+- Direct Midi Input: The note editor has a button to allow entering notes
+by MIDI (i.e. while not recording). ([#170][i170])
+  - Polyphony is supported if there are tracks available. 
+  - The velocity of the last MIDI input note can be sent to another track
+  (selector next to the MIDI button in the note editor), optionally. 
 - Units can have comments, to make it easier to distinguish between units of
   same type within an instrument. These comments are also shown when choosing
   the send target. ([#114][i114])

--- a/cmd/sointu-track/main.go
+++ b/cmd/sointu-track/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	trackerUi := gioui.NewTracker(model)
 	audioCloser := audioContext.Play(func(buf sointu.AudioBuffer) error {
-		player.Process(buf, midiContext, trackerUi)
+		player.Process(buf, midiContext)
 		return nil
 	})
 

--- a/cmd/sointu-vsti/main.go
+++ b/cmd/sointu-vsti/main.go
@@ -109,7 +109,7 @@ func init() {
 						buf = append(buf, make(sointu.AudioBuffer, out.Frames-len(buf))...)
 					}
 					buf = buf[:out.Frames]
-					player.Process(buf, &context, nil)
+					player.Process(buf, &context)
 					for i := 0; i < out.Frames; i++ {
 						left[i], right[i] = buf[i][0], buf[i][1]
 					}

--- a/tracker/bool.go
+++ b/tracker/bool.go
@@ -112,12 +112,15 @@ func (m *Follow) Value() bool       { return m.follow }
 func (m *Follow) setValue(val bool) { m.follow = val }
 func (m *Follow) Enabled() bool     { return true }
 
-// TrackMidiIn (Midi Input for notes in the tracks)
+// Midi Input for notes in the tracks
 
-func (m *TrackMidiIn) Bool() Bool        { return Bool{m} }
-func (m *TrackMidiIn) Value() bool       { return m.trackMidiIn }
-func (m *TrackMidiIn) setValue(val bool) { m.trackMidiIn = val }
-func (m *TrackMidiIn) Enabled() bool     { return m.MIDI.HasDeviceOpen() }
+func (m *TrackMidiIn) Bool() Bool  { return Bool{m} }
+func (m *TrackMidiIn) Value() bool { return m.trackMidiIn }
+func (m *TrackMidiIn) setValue(val bool) {
+	m.trackMidiIn = val
+	((*Model)(m)).updatePlayerConstraints()
+}
+func (m *TrackMidiIn) Enabled() bool { return m.MIDI.HasDeviceOpen() }
 
 // Effect methods
 

--- a/tracker/gioui/buttons.go
+++ b/tracker/gioui/buttons.go
@@ -44,6 +44,14 @@ type (
 		TipArea   component.TipArea
 		Bool      tracker.Bool
 	}
+
+	MenuClickable struct {
+		Clickable Clickable
+		menu      Menu
+		Selected  tracker.OptionalInt
+		TipArea   component.TipArea
+		Tooltip   component.Tooltip
+	}
 )
 
 func NewActionClickable(a tracker.Action) *ActionClickable {
@@ -136,7 +144,10 @@ func ToggleButton(gtx C, th *material.Theme, b *BoolClickable, text string) Butt
 	ret := Button(th, &b.Clickable, text)
 	ret.Background = transparent
 	ret.Inset = layout.UniformInset(unit.Dp(6))
-	if b.Bool.Value() {
+	if !b.Bool.Enabled() {
+		ret.Color = disabledTextColor
+		ret.Background = transparent
+	} else if b.Bool.Value() {
 		ret.Color = th.Palette.ContrastFg
 		ret.Background = th.Palette.Fg
 	} else {
@@ -287,6 +298,7 @@ type ButtonStyle struct {
 	Inset        layout.Inset
 	Button       *Clickable
 	shaper       *text.Shaper
+	Hidden       bool
 }
 
 type ButtonLayoutStyle struct {
@@ -351,6 +363,9 @@ func (b ButtonStyle) Layout(gtx layout.Context) layout.Dimensions {
 		CornerRadius: b.CornerRadius,
 		Button:       b.Button,
 	}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+		if b.Hidden {
+			return layout.Dimensions{}
+		}
 		return b.Inset.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 			colMacro := op.Record(gtx.Ops)
 			paint.ColorOp{Color: b.Color}.Add(gtx.Ops)

--- a/tracker/gioui/iconcache.go
+++ b/tracker/gioui/iconcache.go
@@ -10,6 +10,9 @@ var iconCache = map[*byte]*widget.Icon{}
 
 // widgetForIcon returns a widget for IconVG data, but caching the results
 func widgetForIcon(icon []byte) *widget.Icon {
+	if icon == nil {
+		return nil
+	}
 	if widget, ok := iconCache[&icon[0]]; ok {
 		return widget
 	}

--- a/tracker/gioui/label.go
+++ b/tracker/gioui/label.go
@@ -46,5 +46,17 @@ func (l LabelStyle) Layout(gtx layout.Context) layout.Dimensions {
 }
 
 func Label(str string, color color.NRGBA, shaper *text.Shaper) layout.Widget {
-	return LabelStyle{Text: str, Color: color, ShadeColor: black, Font: labelDefaultFont, FontSize: labelDefaultFontSize, Alignment: layout.W, Shaper: shaper}.Layout
+	return SizedLabel(str, color, shaper, labelDefaultFontSize)
+}
+
+func SizedLabel(str string, color color.NRGBA, shaper *text.Shaper, fontSize unit.Sp) layout.Widget {
+	return LabelStyle{
+		Text:       str,
+		Color:      color,
+		ShadeColor: black,
+		Font:       labelDefaultFont,
+		FontSize:   fontSize,
+		Alignment:  layout.W,
+		Shaper:     shaper,
+	}.Layout
 }

--- a/tracker/gioui/note_editor.go
+++ b/tracker/gioui/note_editor.go
@@ -2,6 +2,7 @@ package gioui
 
 import (
 	"fmt"
+	"gioui.org/x/component"
 	"image"
 	"image/color"
 	"strconv"
@@ -64,6 +65,7 @@ type NoteEditor struct {
 	EffectBtn           *BoolClickable
 	UniqueBtn           *BoolClickable
 	TrackMidiInBtn      *BoolClickable
+	TrackForMidiVelIn   *MenuClickable
 
 	scrollTable  *ScrollTable
 	eventFilters []event.Filter
@@ -88,6 +90,7 @@ func NewNoteEditor(model *tracker.Model) *NoteEditor {
 		EffectBtn:           NewBoolClickable(model.Effect().Bool()),
 		UniqueBtn:           NewBoolClickable(model.UniquePatterns().Bool()),
 		TrackMidiInBtn:      NewBoolClickable(model.TrackMidiIn().Bool()),
+		TrackForMidiVelIn:   &MenuClickable{Selected: model.TrackForMidiVelIn().OptionalInt()},
 		scrollTable: NewScrollTable(
 			model.Notes().Table(),
 			model.Tracks().List(),
@@ -158,14 +161,12 @@ func (te *NoteEditor) layoutButtons(gtx C, t *Tracker) D {
 		deleteTrackBtnStyle := ActionIcon(gtx, t.Theme, te.DeleteTrackBtn, icons.ActionDelete, te.deleteTrackHint)
 		splitTrackBtnStyle := ActionIcon(gtx, t.Theme, te.SplitTrackBtn, icons.CommunicationCallSplit, te.splitTrackHint)
 		newTrackBtnStyle := ActionIcon(gtx, t.Theme, te.NewTrackBtn, icons.ContentAdd, te.addTrackHint)
-		in := layout.UniformInset(unit.Dp(1))
-		voiceUpDown := func(gtx C) D {
-			numStyle := NumericUpDown(t.Theme, te.TrackVoices, "Number of voices for this track")
-			return in.Layout(gtx, numStyle.Layout)
-		}
+		voiceUpDown := NumericUpDownPadded(t.Theme, te.TrackVoices, "Number of voices for this track", 1)
 		effectBtnStyle := ToggleButton(gtx, t.Theme, te.EffectBtn, "Hex")
 		uniqueBtnStyle := ToggleIcon(gtx, t.Theme, te.UniqueBtn, icons.ToggleStarBorder, icons.ToggleStar, te.uniqueOffTip, te.uniqueOnTip)
 		midiInBtnStyle := ToggleButton(gtx, t.Theme, te.TrackMidiInBtn, "MIDI")
+		midiInBtnStyle.Hidden = !t.HasAnyMidiInput()
+		trackForMidiVelInSelector := te.layoutMidiVelInTrackSelector(t, " vel:")
 		return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
 			layout.Rigid(func(gtx C) D { return layout.Dimensions{Size: image.Pt(gtx.Dp(unit.Dp(12)), 0)} }),
 			layout.Rigid(addSemitoneBtnStyle.Layout),
@@ -176,14 +177,60 @@ func (te *NoteEditor) layoutButtons(gtx C, t *Tracker) D {
 			layout.Rigid(effectBtnStyle.Layout),
 			layout.Rigid(uniqueBtnStyle.Layout),
 			layout.Rigid(Label("  Voices:", white, t.Theme.Shaper)),
-			layout.Rigid(voiceUpDown),
+			layout.Rigid(voiceUpDown.Layout),
 			layout.Rigid(splitTrackBtnStyle.Layout),
 			layout.Flexed(1, func(gtx C) D { return layout.Dimensions{Size: gtx.Constraints.Min} }),
 			layout.Rigid(midiInBtnStyle.Layout),
+			layout.Rigid(trackForMidiVelInSelector),
 			layout.Flexed(1, func(gtx C) D { return layout.Dimensions{Size: gtx.Constraints.Min} }),
 			layout.Rigid(deleteTrackBtnStyle.Layout),
 			layout.Rigid(newTrackBtnStyle.Layout))
 	})
+}
+
+func (te *NoteEditor) layoutMidiVelInTrackSelector(t *Tracker, label string) func(gtx C) D {
+	if !t.HasAnyMidiInput() {
+		return layout.Spacer{}.Layout
+	}
+	tracks := t.Model.Tracks().List()
+	trackItems := make([]MenuItem, tracks.Count()+1)
+	trackForMidiVelIn := t.Model.TrackForMidiVelIn()
+	offText := "\u2014off\u2014"
+	currentText := offText
+	for i := range trackItems {
+		trackItems[i] = MenuItem{
+			Text: offText,
+			Doer: tracker.Check(
+				func() { trackForMidiVelIn.OptionalInt().Set(i-1, i > 0) },
+				func() bool { return t.Model.CanUseTrackForMidiVelInput(i - 1) },
+			),
+		}
+		if i > 0 {
+			trackItems[i].Text = fmt.Sprintf("%d %s", i-1, t.Model.TrackTitle(i-1))
+		}
+
+		if trackForMidiVelIn.OptionalInt().Equals(i-1, i > 0) {
+			trackItems[i].IconBytes = icons.NavigationChevronRight
+			if trackForMidiVelIn.IsValid() {
+				currentText = trackItems[i].Text
+			}
+		}
+	}
+	return func(gtx C) D {
+		tooltip := component.PlatformTooltip(t.Theme, "Record MIDI VEL into chosen track. This can not be one of the selected tracks (where MIDI Notes go).")
+		return te.TrackForMidiVelIn.TipArea.Layout(gtx, tooltip, func(gtx C) D {
+			return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
+				layout.Rigid(SizedLabel(label, white, t.Theme.Shaper, unit.Sp(12))),
+				layout.Rigid(t.layoutMenu(gtx,
+					currentText,
+					&te.TrackForMidiVelIn.Clickable,
+					&te.TrackForMidiVelIn.menu,
+					unit.Dp(200),
+					trackItems...,
+				)),
+			)
+		})
+	}
 }
 
 const baseNote = 24
@@ -287,16 +334,19 @@ func (te *NoteEditor) layoutTracks(gtx C, t *Tracker) D {
 				c = cursorColor
 			}
 			if hasTrackMidiIn {
-				c = cursorForTrackMidiInColor
+				c = trackMidiInCurrentColor
 			}
-			te.paintColumnCell(gtx, x, t, c)
+			te.paintColumnCell(gtx, x, t, c, hasTrackMidiIn)
 		}
 		// draw the corresponding "fake cursors" for instrument-track-groups (for polyphony)
-		if hasTrackMidiIn {
+		if hasTrackMidiIn && y == cursor.Y {
 			for _, trackIndex := range t.Model.TracksWithSameInstrumentAsCurrent() {
-				if x == trackIndex && y == cursor.Y {
-					te.paintColumnCell(gtx, x, t, cursorNeighborForTrackMidiInColor)
+				if x == trackIndex {
+					te.paintColumnCell(gtx, x, t, trackMidiInAdditionalColor, hasTrackMidiIn)
 				}
+			}
+			if t.Model.TrackForMidiVelIn().Equals(x) {
+				te.paintColumnCell(gtx, x, t, trackMidiVelInColor, hasTrackMidiIn)
 			}
 		}
 
@@ -334,10 +384,10 @@ func (te *NoteEditor) layoutTracks(gtx C, t *Tracker) D {
 	return table.Layout(gtx)
 }
 
-func (te *NoteEditor) paintColumnCell(gtx C, x int, t *Tracker, c color.NRGBA) {
+func (te *NoteEditor) paintColumnCell(gtx C, x int, t *Tracker, c color.NRGBA, ignoreEffect bool) {
 	cw := gtx.Constraints.Min.X
 	cx := 0
-	if t.Model.Notes().Effect(x) {
+	if t.Model.Notes().Effect(x) && !ignoreEffect {
 		cw /= 2
 		if t.Model.Notes().LowNibble() {
 			cx += cw
@@ -405,22 +455,4 @@ func (te *NoteEditor) finishNoteInsert(t *Tracker, note byte, keyName key.Name) 
 		trk := te.scrollTable.Table.Cursor().X
 		t.KeyPlaying[keyName] = t.TrackNoteOn(trk, note)
 	}
-}
-
-func (te *NoteEditor) HandleMidiInput(t *Tracker) {
-	inputDeactivated := !t.Model.TrackMidiIn().Value()
-	if inputDeactivated {
-		return
-	}
-	te.scrollTable.Table.SetCursor2(te.scrollTable.Table.Cursor())
-	remaining := t.Model.CountNextTracksForCurrentInstrument()
-	for i, note := range t.MidiNotePlaying {
-		t.Model.Notes().Table().Set(note)
-		te.scrollTable.Table.MoveCursor(1, 0)
-		te.scrollTable.EnsureCursorVisible()
-		if i >= remaining {
-			break
-		}
-	}
-	te.scrollTable.Table.SetCursor(te.scrollTable.Table.Cursor2())
 }

--- a/tracker/gioui/numericupdown.go
+++ b/tracker/gioui/numericupdown.go
@@ -48,7 +48,9 @@ type NumericUpDownStyle struct {
 	Tooltip         component.Tooltip
 	Width           unit.Dp
 	Height          unit.Dp
+	Padding         unit.Dp
 	shaper          text.Shaper
+	Hidden          bool
 }
 
 func NewNumberInput(v tracker.Int) *NumberInput {
@@ -56,6 +58,10 @@ func NewNumberInput(v tracker.Int) *NumberInput {
 }
 
 func NumericUpDown(th *material.Theme, number *NumberInput, tooltip string) NumericUpDownStyle {
+	return NumericUpDownPadded(th, number, tooltip, 0)
+}
+
+func NumericUpDownPadded(th *material.Theme, number *NumberInput, tooltip string, padding int) NumericUpDownStyle {
 	bgColor := th.Palette.Fg
 	bgColor.R /= 4
 	bgColor.G /= 4
@@ -74,11 +80,22 @@ func NumericUpDown(th *material.Theme, number *NumberInput, tooltip string) Nume
 		Tooltip:         Tooltip(th, tooltip),
 		Width:           unit.Dp(70),
 		Height:          unit.Dp(20),
+		Padding:         unit.Dp(padding),
 		shaper:          *th.Shaper,
 	}
 }
 
 func (s *NumericUpDownStyle) Layout(gtx C) D {
+	if s.Hidden {
+		return D{}
+	}
+	if s.Padding <= 0 {
+		return s.layoutWithTooltip(gtx)
+	}
+	return layout.UniformInset(s.Padding).Layout(gtx, s.layoutWithTooltip)
+}
+
+func (s *NumericUpDownStyle) layoutWithTooltip(gtx C) D {
 	if s.Tooltip.Text.Text != "" {
 		return s.NumberInput.tipArea.Layout(gtx, s.Tooltip, s.actualLayout)
 	}

--- a/tracker/gioui/songpanel.go
+++ b/tracker/gioui/songpanel.go
@@ -7,14 +7,13 @@ import (
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
 	"gioui.org/unit"
-	"gioui.org/widget"
 	"github.com/vsariola/sointu/tracker"
 	"github.com/vsariola/sointu/version"
 	"golang.org/x/exp/shiny/materialdesign/icons"
 )
 
 type SongPanel struct {
-	MenuBar        []widget.Clickable
+	MenuBar        []Clickable
 	Menus          []Menu
 	BPM            *NumberInput
 	RowsPerPattern *NumberInput
@@ -57,7 +56,7 @@ type SongPanel struct {
 
 func NewSongPanel(model *tracker.Model) *SongPanel {
 	ret := &SongPanel{
-		MenuBar:        make([]widget.Clickable, 3),
+		MenuBar:        make([]Clickable, 3),
 		Menus:          make([]Menu, 3),
 		BPM:            NewNumberInput(model.BPM().Int()),
 		RowsPerPattern: NewNumberInput(model.RowsPerPattern().Int()),

--- a/tracker/gioui/theme.go
+++ b/tracker/gioui/theme.go
@@ -60,8 +60,10 @@ var activeLightSurfaceColor = color.NRGBA{R: 45, G: 45, B: 45, A: 255}
 var cursorColor = color.NRGBA{R: 100, G: 140, B: 255, A: 48}
 var selectionColor = color.NRGBA{R: 100, G: 140, B: 255, A: 12}
 var inactiveSelectionColor = color.NRGBA{R: 140, G: 140, B: 140, A: 16}
-var cursorForTrackMidiInColor = color.NRGBA{R: 255, G: 100, B: 140, A: 48}
-var cursorNeighborForTrackMidiInColor = color.NRGBA{R: 255, G: 100, B: 140, A: 24}
+
+var trackMidiInCurrentColor = color.NRGBA{R: 255, G: 100, B: 140, A: 48}
+var trackMidiInAdditionalColor = withScaledAlpha(trackMidiInCurrentColor, 0.7)
+var trackMidiVelInColor = withScaledAlpha(trackMidiInCurrentColor, 0.3)
 
 var errorColor = color.NRGBA{R: 207, G: 102, B: 121, A: 255}
 
@@ -75,3 +77,13 @@ var dialogBgColor = color.NRGBA{R: 0, G: 0, B: 0, A: 224}
 
 var paramIsSendTargetColor = color.NRGBA{R: 120, G: 120, B: 210, A: 255}
 var paramValueInvalidColor = color.NRGBA{R: 120, G: 120, B: 120, A: 190}
+
+func withScaledAlpha(c color.NRGBA, factor float32) color.NRGBA {
+	A := factor * float32(c.A)
+	return color.NRGBA{
+		R: c.R,
+		G: c.G,
+		B: c.B,
+		A: uint8(A),
+	}
+}

--- a/tracker/gioui/unit_editor.go
+++ b/tracker/gioui/unit_editor.go
@@ -32,7 +32,7 @@ type UnitEditor struct {
 	CopyUnitBtn    *TipClickable
 	ClearUnitBtn   *ActionClickable
 	DisableUnitBtn *BoolClickable
-	SelectTypeBtn  *widget.Clickable
+	SelectTypeBtn  *Clickable
 	commentEditor  *Editor
 	caser          cases.Caser
 
@@ -47,7 +47,7 @@ func NewUnitEditor(m *tracker.Model) *UnitEditor {
 		ClearUnitBtn:   NewActionClickable(m.ClearUnit()),
 		DisableUnitBtn: NewBoolClickable(m.UnitDisabled().Bool()),
 		CopyUnitBtn:    new(TipClickable),
-		SelectTypeBtn:  new(widget.Clickable),
+		SelectTypeBtn:  new(Clickable),
 		commentEditor:  NewEditor(widget.Editor{SingleLine: true, Submit: true}),
 		sliderList:     NewDragList(m.Params().List(), layout.Vertical),
 		searchList:     NewDragList(m.SearchResults().List(), layout.Vertical),
@@ -236,9 +236,9 @@ func (pe *UnitEditor) command(e key.Event, t *Tracker) {
 type ParameterWidget struct {
 	floatWidget widget.Float
 	boolWidget  widget.Bool
-	instrBtn    widget.Clickable
+	instrBtn    Clickable
 	instrMenu   Menu
-	unitBtn     widget.Clickable
+	unitBtn     Clickable
 	unitMenu    Menu
 	Parameter   tracker.Parameter
 	tipArea     component.TipArea
@@ -332,7 +332,6 @@ func (p ParameterStyle) Layout(gtx C) D {
 				gtx.Constraints.Min.Y = gtx.Dp(unit.Dp(40))
 				instrItems := make([]MenuItem, p.tracker.Instruments().Count())
 				for i := range instrItems {
-					i := i
 					name, _, _, _ := p.tracker.Instruments().Item(i)
 					instrItems[i].Text = name
 					instrItems[i].IconBytes = icons.NavigationChevronRight

--- a/tracker/int.go
+++ b/tracker/int.go
@@ -45,6 +45,7 @@ func (v Int) Add(delta int) (ok bool) {
 func (v Int) Set(value int) (ok bool) {
 	r := v.Range()
 	value = v.Range().Clamp(value)
+	// qm210: Question: how can the Min/Max checks even be true after the preceding Clamp() ?
 	if value == v.Value() || value < r.Min || value > r.Max {
 		return false
 	}

--- a/tracker/list.go
+++ b/tracker/list.go
@@ -428,7 +428,7 @@ func (v *Tracks) Selected2() int {
 }
 
 func (v *Tracks) SetSelected(value int) {
-	v.d.Cursor.Track = max(min(value, v.Count()-1), 0)
+	(*Model)(v).ChangeTrack(value)
 }
 
 func (v *Tracks) SetSelected2(value int) {

--- a/tracker/model_test.go
+++ b/tracker/model_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/vsariola/sointu/tracker"
+	"github.com/vsariola/sointu/tracker/types"
 	"github.com/vsariola/sointu/vm"
 )
 
@@ -22,6 +23,12 @@ func (NullContext) FinishBlock(frame int) {}
 func (NullContext) BPM() (bpm float64, ok bool) {
 	return 0, false
 }
+
+func (NullContext) MaxPolyphony() types.OptionalInteger {
+	return types.NewEmptyOptionalInteger()
+}
+
+func (NullContext) SetMaxPolyphony(v types.OptionalInteger) {}
 
 func (NullContext) InputDevices(yield func(tracker.MIDIDevice) bool) {}
 
@@ -277,7 +284,7 @@ func FuzzModel(f *testing.F) {
 					break loop
 				default:
 					ctx := NullContext{}
-					player.Process(buf, ctx, nil)
+					player.Process(buf, ctx)
 				}
 			}
 		}()

--- a/tracker/optional_int.go
+++ b/tracker/optional_int.go
@@ -1,0 +1,81 @@
+package tracker
+
+import "github.com/vsariola/sointu/tracker/types"
+
+type (
+	// OptionalInt tries to follow the same convention as e.g. Int{...} or Bool{...}
+	// Do not confuse with types.OptionalInteger, which you might use as a model,
+	// but don't necessarily have to.
+	OptionalInt struct {
+		optionalIntData
+	}
+
+	optionalIntData interface {
+		Unpack() (int, bool)
+		Value() int
+		Range() intRange
+
+		setValue(int)
+		unsetValue()
+		change(kind string) func()
+	}
+
+	TrackMidiVelIn Model
+)
+
+func (v OptionalInt) Set(value int, present bool) (ok bool) {
+	if !present {
+		v.unsetValue()
+		return true
+	}
+	// TODO: can we deduplicate this by referencing Int{...}.Set(value) ?
+	r := v.Range()
+	if v.Equals(value, present) || value < r.Min || value > r.Max {
+		return false
+	}
+	defer v.change("Set")()
+	v.setValue(value)
+	return true
+}
+
+func (v OptionalInt) Equals(value int, present bool) bool {
+	oldValue, oldPresent := v.Unpack()
+	return value == oldValue && present == oldPresent
+}
+
+// Model methods
+
+func (m *Model) TrackForMidiVelIn() *TrackMidiVelIn { return (*TrackMidiVelIn)(m) }
+
+// TrackForMidiVelIn - to record Velocity in the track with given number (-1 = off)
+
+func (m *TrackMidiVelIn) OptionalInt() OptionalInt { return OptionalInt{m} }
+func (m *TrackMidiVelIn) Range() intRange          { return intRange{0, len(m.d.Song.Score.Tracks) - 1} }
+func (m *TrackMidiVelIn) change(string) func()     { return func() {} }
+
+func (m *TrackMidiVelIn) setValue(val int) {
+	m.trackForMidiVelIn = types.NewOptionalInteger(val, val >= 0)
+}
+
+func (m *TrackMidiVelIn) unsetValue() {
+	m.trackForMidiVelIn = types.NewEmptyOptionalInteger()
+}
+
+func (m *TrackMidiVelIn) Unpack() (int, bool) {
+	return m.trackForMidiVelIn.Unpack()
+}
+
+func (m *TrackMidiVelIn) Value() int {
+	return m.trackForMidiVelIn.Value()
+}
+
+func (m *TrackMidiVelIn) IsValid() bool {
+	if m.trackForMidiVelIn.Empty() {
+		return true
+	}
+	return (*Model)(m).CanUseTrackForMidiVelInput(m.trackForMidiVelIn.Value())
+}
+
+func (m *TrackMidiVelIn) Equals(value int) bool {
+	return m.trackForMidiVelIn.Equals(value)
+}

--- a/tracker/table.go
+++ b/tracker/table.go
@@ -173,7 +173,7 @@ func (m *Order) Cursor2() Point {
 }
 
 func (m *Order) SetCursor(p Point) {
-	m.d.Cursor.Track = max(min(p.X, len(m.d.Song.Score.Tracks)-1), 0)
+	(*Model)(m).ChangeTrack(p.X)
 	y := max(min(p.Y, m.d.Song.Score.Length-1), 0)
 	if y != m.d.Cursor.OrderRow {
 		m.follow = false
@@ -385,7 +385,7 @@ func (m *Notes) Cursor2() Point {
 }
 
 func (v *Notes) SetCursor(p Point) {
-	v.d.Cursor.Track = max(min(p.X, len(v.d.Song.Score.Tracks)-1), 0)
+	(*Model)(v).ChangeTrack(p.X)
 	newPos := v.d.Song.Score.Clamp(sointu.SongPos{PatternRow: p.Y})
 	if newPos != v.d.Cursor.SongPos {
 		v.follow = false

--- a/tracker/types/optional.go
+++ b/tracker/types/optional.go
@@ -1,0 +1,47 @@
+package types
+
+type (
+	// OptionalInteger is the simple struct, not to be confused with tracker.OptionalInt.
+	// It implements the tracker.optionalIntData interface, without needing to know so.
+	OptionalInteger struct {
+		value  int
+		exists bool
+	}
+)
+
+func NewOptionalInteger(value int, exists bool) OptionalInteger {
+	return OptionalInteger{value, exists}
+}
+
+func NewOptionalIntegerOf(value int) OptionalInteger {
+	return OptionalInteger{
+		value:  value,
+		exists: true,
+	}
+}
+
+func NewEmptyOptionalInteger() OptionalInteger {
+	// could also just use OptionalInteger{}
+	return OptionalInteger{
+		exists: false,
+	}
+}
+
+func (i OptionalInteger) Unpack() (int, bool) {
+	return i.value, i.exists
+}
+
+func (i OptionalInteger) Value() int {
+	if !i.exists {
+		panic("Access value of empty OptionalInteger")
+	}
+	return i.value
+}
+
+func (i OptionalInteger) Empty() bool {
+	return !i.exists
+}
+
+func (i OptionalInteger) Equals(value int) bool {
+	return i.exists && i.value == value
+}


### PR DESCRIPTION
Hi pestis,

this is probably large, but I do not know whether overly-large.

I noticed that my polyphonic midi input from a few weeks back (direct track input via my button, not the recording function) was not actually doing its thing as intended, and I wanted to add a way to also write the velocity of the midi input into another chosen track.

doing so included a lot of thoughts, discussion about structure with @LeStahL , and finally this solution which does its job, but might be a lot to review. anticipating your comments! :grimacing: 

