### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ WebAssembly example:
 
 ```
 sointu-compile -o . -arch=wasm tests/test_chords.yml
-wat2wasm --enable-bulk-memory test_chords.wat
+wat2wasm test_chords.wat
 ```
 
 If you are looking for an easy way to compile an executable from a Sointu song


### PR DESCRIPTION
Now it seems bulk memory is enabled by default in wat2wasm

See: https://github.com/WebAssembly/wabt/pull/1728