### PR TITLE
feat: noisegate unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the loudness and peak detector. ([#210][i210])
 - More presets from Reaby, and all new and existing presets were normalized
   roughly to -12 dBFS true peak. ([#211][i211])
+- noisegate unit: suppress signals below a threshold power. Parameters are
+  the attack (time to close the gate), release (time to open up again) and
+  hold times (how long, below threshold, to delay the closing) ([#109][i109])
 
 ### Fixed
 - VSTi queries the host sample rate more robustly. Cubase previously reported

--- a/patch.go
+++ b/patch.go
@@ -273,20 +273,11 @@ var UnitTypes = map[string]UnitType{
 			{Name: "stereo", MinValue: 0, MaxValue: 1, CanSet: true, CanModulate: false},
 			{Name: "attack", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
 			{Name: "release", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
-			{Name: "invgain", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: func(v int) (string, string) {
-				return strconv.FormatFloat(toDecibel(128/float64(v)), 'g', 3, 64), "dB"
-			}},
-			{Name: "threshold", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: func(v int) (string, string) {
-				return strconv.FormatFloat(toDecibel(float64(v)/128), 'g', 3, 64), "dB"
-			}},
+			{Name: "invgain", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelLevelDispFunc},
+			{Name: "threshold", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelLevelDispFunc},
 			{Name: "ratio", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: func(v int) (string, string) { return formatFloat(1 - float64(v)/128), "" }},
 		},
-		StackUse: func(u *Unit) StackUse {
-			if stereo, ok := u.Parameters["stereo"]; ok && stereo == 1 {
-				return StackUse{Inputs: [][]int{{0, 2, 3}, {1, 2, 3}}, Modifies: []bool{false, false, true, true}, NumOutputs: 4}
-			}
-			return StackUse{Inputs: [][]int{{0, 1}}, Modifies: []bool{false, true}, NumOutputs: 2}
-		},
+		StackUse: stackUseCalculateFactor,
 	},
 	"speed": {
 		Params:   []UnitParameter{},
@@ -426,6 +417,16 @@ var UnitTypes = map[string]UnitType{
 		},
 		StackUse: stackUseEffect,
 	},
+	"noisegate": {
+		Params: []UnitParameter{
+			{Name: "stereo", MinValue: 0, MaxValue: 1, CanSet: true, CanModulate: false},
+			{Name: "threshold", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelLevelDispFunc},
+			{Name: "attack", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
+			{Name: "release", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
+			{Name: "hold", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
+		},
+		StackUse: stackUseCalculateFactor,
+	},
 }
 
 func stackUseSource(u *Unit) StackUse {
@@ -447,6 +448,15 @@ func stackUseEffect(u *Unit) StackUse {
 		return StackUse{Inputs: [][]int{{0}, {1}}, Modifies: []bool{true, true}, NumOutputs: 2}
 	}
 	return StackUse{Inputs: [][]int{{0}}, Modifies: []bool{true}, NumOutputs: 1}
+}
+
+// Effects like the Compressor add their calculated factor on top of the stack,
+// for greater flexibility (so you usually "mulp" this directly, but can choose otherwise)
+func stackUseCalculateFactor(u *Unit) StackUse {
+	if stereo, ok := u.Parameters["stereo"]; ok && stereo == 1 {
+		return StackUse{Inputs: [][]int{{0, 2, 3}, {1, 2, 3}}, Modifies: []bool{false, false, true, true}, NumOutputs: 4}
+	}
+	return StackUse{Inputs: [][]int{{0, 1}}, Modifies: []bool{false, true}, NumOutputs: 2}
 }
 
 // compile errors if interface is not implemented.
@@ -488,6 +498,10 @@ func compressorTimeDispFunc(v int) (string, string) {
 	alpha := math.Pow(2, -24*float64(v)/128) // alpha is the "smoothing factor" of first order low pass iir
 	sec := -1 / (44100 * math.Log(1-alpha))  // from smoothing factor to time constant, https://en.wikipedia.org/wiki/Exponential_smoothing
 	return engineeringTime(sec)
+}
+
+func decibelLevelDispFunc(v int) (string, string) {
+	return strconv.FormatFloat(toDecibel(float64(v)/128), 'g', 3, 64), "dB"
 }
 
 func engineeringTime(sec float64) (string, string) {

--- a/patch.go
+++ b/patch.go
@@ -201,14 +201,14 @@ var UnitTypes = map[string]UnitType{
 	"gain": {
 		Params: []UnitParameter{
 			{Name: "stereo", MinValue: 0, MaxValue: 1, CanSet: true, CanModulate: false},
-			{Name: "gain", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: func(v int) (string, string) { return strconv.FormatFloat(toDecibel(float64(v)/128), 'g', 3, 64), "dB" }},
+			{Name: "gain", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelLevelDispFunc},
 		},
 		StackUse: stackUseEffect,
 	},
 	"invgain": {
 		Params: []UnitParameter{
 			{Name: "stereo", MinValue: 0, MaxValue: 1, CanSet: true, CanModulate: false},
-			{Name: "invgain", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: func(v int) (string, string) { return strconv.FormatFloat(toDecibel(128/float64(v)), 'g', 3, 64), "dB" }},
+			{Name: "invgain", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelInverseDispFunc},
 		},
 		StackUse: stackUseEffect,
 	},
@@ -273,7 +273,7 @@ var UnitTypes = map[string]UnitType{
 			{Name: "stereo", MinValue: 0, MaxValue: 1, CanSet: true, CanModulate: false},
 			{Name: "attack", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
 			{Name: "release", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
-			{Name: "invgain", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelLevelDispFunc},
+			{Name: "invgain", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelInverseDispFunc},
 			{Name: "threshold", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelLevelDispFunc},
 			{Name: "ratio", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: func(v int) (string, string) { return formatFloat(1 - float64(v)/128), "" }},
 		},
@@ -417,13 +417,13 @@ var UnitTypes = map[string]UnitType{
 		},
 		StackUse: stackUseEffect,
 	},
-	"noisegate": {
+	"gate": {
 		Params: []UnitParameter{
 			{Name: "stereo", MinValue: 0, MaxValue: 1, CanSet: true, CanModulate: false},
-			{Name: "threshold", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelLevelDispFunc},
-			{Name: "attack", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
-			{Name: "release", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
-			{Name: "hold", MinValue: 0, Default: 64, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
+			{Name: "release", MinValue: 0, Default: 24, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
+			{Name: "hold", MinValue: 0, Default: 24, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
+			{Name: "attack", MinValue: 0, Default: 24, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: compressorTimeDispFunc},
+			{Name: "threshold", MinValue: 0, Default: 0, MaxValue: 128, CanSet: true, CanModulate: true, DisplayFunc: decibelLevelDispFunc},
 		},
 		StackUse: stackUseCalculateFactor,
 	},
@@ -502,6 +502,10 @@ func compressorTimeDispFunc(v int) (string, string) {
 
 func decibelLevelDispFunc(v int) (string, string) {
 	return strconv.FormatFloat(toDecibel(float64(v)/128), 'g', 3, 64), "dB"
+}
+
+func decibelInverseDispFunc(v int) (string, string) {
+	return strconv.FormatFloat(toDecibel(128/float64(v)), 'g', 3, 64), "dB"
 }
 
 func engineeringTime(sec float64) (string, string) {

--- a/vm/compiler/templates/amd64-386/effects.asm
+++ b/vm/compiler/templates/amd64-386/effects.asm
@@ -493,79 +493,74 @@ su_op_compressor_mono:
 {{- end}}
 
 
-{{- if .HasOp "noisegate"}}
+
+{{- if .HasOp "gate"}}
 ;-------------------------------------------------------------------------------
-;   NOISEGATE opcode: push noisegate gain to stack
+;   GATE opcode: push noise gate gain to stack
 ;-------------------------------------------------------------------------------
 ;   Mono:   push g on stack, where g is a suitable gain for the signal
 ;           you can then MULP to actually gate the signal or SEND it somewhere
 ;   Stereo: push g g on stack, where g is calculated using the max(l, r) signal
 ;-------------------------------------------------------------------------------
-{{.Func "su_op_noisegate" "Opcode"}}
+{{.Func "su_op_gate" "Opcode"}}
     fld     st0                                 ; x x
     fmul    st0, st0                            ; x^2 x
-{{- if .StereoAndMono "noisegate"}}
-    jnc     su_op_noisegate_mono
+{{- if .StereoAndMono "gate"}}
+    jnc     su_op_gate_mono
 {{- end}}
-{{- if .Stereo "noisegate"}}
+{{- if .Stereo "gate"}}
     fld     st2                                 ; r x^2 l r
     fst     st3                                 ; y x^2 l r
     fmul    st0, st0                            ; y^2 x^2 l r
-    fucomi  st0, st1
-    fcmovb  st0, st1                            ; (y^2 < x^2 ? x^2 : y^2) x^2 l r
-    fstp    st1                                 ; max(x,y)^2 l r
-{{- if .StereoAndMono "noisegate"}}
-    call    su_op_noisegate_mono
+    faddp   st1, st0                            ; y^2+x^2 l r
+{{- if .StereoAndMono "gate"}}
+    call    su_op_gate_mono
     fld     st0
     ret
-su_op_noisegate_mono:                           ; (...==signal) x
+su_op_gate_mono:                                ; (...==signal) x
 {{- end}}
 {{- end}}
-    fld     dword [{{.Input "noisegate" "threshold"}}] ; threshold signal x
+    fld     dword [{{.Input "gate" "threshold"}}] ; threshold signal x
     fmul    st0, st0                            ; threshold^2 signal x
     fucomip st0, st1                            ; signal x
     fstp    st0                                 ; x
     fld     dword [{{.WRK}}+4]                  ; holding x
-    jae     su_op_noisegate_holding             ;; (signal <= threshold) -> jump
+    jae     su_op_gate_holding                  ;; (signal <= threshold) -> jump
     fstp    st0                                 ; x
     fld1                                        ; (1==holding) x
-    jmp     su_op_noisegate_evaluate
-su_op_noisegate_holding:
-    mov     al, {{.InputNumber "noisegate" "hold"}}
+    jmp     su_op_gate_evaluate
+su_op_gate_holding:
+    mov     al, {{.InputNumber "gate" "hold"}}
     {{.Call "su_nonlinear_map"}}                ; holdrate holding x
     fsubp   st1, st0                            ; (remaining holding) x
-su_op_noisegate_evaluate:
-    fld     dword [{{.WRK}}]                    ; (1-level) holding x
-    fld1                                        ; 1 (1-level) holding x
-    fsubrp  st1, st0                            ; level holding x
+su_op_gate_evaluate:
+    fld     dword [{{.WRK}}]                    ; level holding x
     fldz                                        ; 0 level holding x
     fucomip st0, st2                            ; level holding x
-    jae     su_op_noisegate_attack              ;; if (holding <= 0) -> jump
-su_op_noisegate_release:
-    mov     al, {{.InputNumber "noisegate" "release"}}
+    jae     su_op_gate_attack                   ;; if (holding <= 0) -> jump
+su_op_gate_release:
+    mov     al, {{.InputNumber "gate" "release"}}
     {{.Call "su_nonlinear_map"}}                ; release level holding x
     faddp   st1, st0                            ; (level+release) holding x
     fld1                                        ; 1 level' holding x
     fucomi  st0, st1                            ; limit level holding x
-    jae     su_op_noisegate_leave               ;; if (limit >= level) -> jump
+    jae     su_op_gate_leave                    ;; if (limit >= level) -> jump
     fxch                                        ; level limit holding x
-    jmp     su_op_noisegate_leave               ; level (limit==level) holding x
-su_op_noisegate_attack:
-    mov     al, {{.InputNumber "noisegate" "attack"}}
+    jmp     su_op_gate_leave                    ; level (limit==level) holding x
+su_op_gate_attack:
+    mov     al, {{.InputNumber "gate" "attack"}}
     {{.Call "su_nonlinear_map"}}                ; attack level holding x
     fsubp  st1, st0                             ; (level-attack) holding x
     fldz                                        ; 0 level' holding x
     fucomi  st0, st1                            ; limit level holding x
-    jbe     su_op_noisegate_leave               ;; if (limit <= level) -> jump
+    jbe     su_op_gate_leave                    ;; if (limit <= level) -> jump
     fxch                                        ; level (limit==level) holding x
-su_op_noisegate_leave:
+su_op_gate_leave:
     fstp    st0                                 ; level holding x
-    fld1                                        ; 1 level holding x
-    fsub    st0, st1                            ; (1-level) level holding x
-    fstp    dword [{{.WRK}}]                    ; level holding x
+    fst     dword [{{.WRK}}]                    ; level holding x
     fxch                                        ; holding level  x
     fstp    dword [{{.WRK}}+4]                  ; level x
-{{- if and (.Stereo "noisegate") (not (.Mono "noisegate"))}}
+{{- if and (.Stereo "gate") (not (.Mono "gate"))}}
     fld     st0                                 ; and return the computed gain two times, ready for MULP STEREO
 {{- end}}
     ret

--- a/vm/compiler/templates/amd64-386/effects.asm
+++ b/vm/compiler/templates/amd64-386/effects.asm
@@ -491,3 +491,82 @@ su_op_compressor_mono:
 {{- end}}
     ret
 {{- end}}
+
+
+{{- if .HasOp "noisegate"}}
+;-------------------------------------------------------------------------------
+;   NOISEGATE opcode: push noisegate gain to stack
+;-------------------------------------------------------------------------------
+;   Mono:   push g on stack, where g is a suitable gain for the signal
+;           you can then MULP to actually gate the signal or SEND it somewhere
+;   Stereo: push g g on stack, where g is calculated using the max(l, r) signal
+;-------------------------------------------------------------------------------
+{{.Func "su_op_noisegate" "Opcode"}}
+    fld     st0                                 ; x x
+    fmul    st0, st0                            ; x^2 x
+{{- if .StereoAndMono "noisegate"}}
+    jnc     su_op_noisegate_mono
+{{- end}}
+{{- if .Stereo "noisegate"}}
+    fld     st2                                 ; r x^2 l r
+    fst     st3                                 ; y x^2 l r
+    fmul    st0, st0                            ; y^2 x^2 l r
+    fucomi  st0, st1
+    fcmovb  st0, st1                            ; (y^2 < x^2 ? x^2 : y^2) x^2 l r
+    fstp    st1                                 ; max(x,y)^2 l r
+{{- if .StereoAndMono "noisegate"}}
+    call    su_op_noisegate_mono
+    fld     st0
+    ret
+su_op_noisegate_mono:                           ; (...==signal) x
+{{- end}}
+{{- end}}
+    fld     dword [{{.Input "noisegate" "threshold"}}] ; threshold signal x
+    fmul    st0, st0                            ; threshold^2 signal x
+    fucomip st0, st1                            ; signal x
+    fstp    st0                                 ; x
+    fld     dword [{{.WRK}}+4]                  ; holding x
+    jae     su_op_noisegate_holding             ;; (signal <= threshold) -> jump
+    fstp    st0                                 ; x
+    fld1                                        ; (1==holding) x
+    jmp     su_op_noisegate_evaluate
+su_op_noisegate_holding:
+    mov     al, {{.InputNumber "noisegate" "hold"}}
+    {{.Call "su_nonlinear_map"}}                ; holdrate holding x
+    fsubp   st1, st0                            ; (remaining holding) x
+su_op_noisegate_evaluate:
+    fld     dword [{{.WRK}}]                    ; (1-level) holding x
+    fld1                                        ; 1 (1-level) holding x
+    fsubrp  st1, st0                            ; level holding x
+    fldz                                        ; 0 level holding x
+    fucomip st0, st2                            ; level holding x
+    jae     su_op_noisegate_attack              ;; if (holding <= 0) -> jump
+su_op_noisegate_release:
+    mov     al, {{.InputNumber "noisegate" "release"}}
+    {{.Call "su_nonlinear_map"}}                ; release level holding x
+    faddp   st1, st0                            ; (level+release) holding x
+    fld1                                        ; 1 level' holding x
+    fucomi  st0, st1                            ; limit level holding x
+    jae     su_op_noisegate_leave               ;; if (limit >= level) -> jump
+    fxch                                        ; level limit holding x
+    jmp     su_op_noisegate_leave               ; level (limit==level) holding x
+su_op_noisegate_attack:
+    mov     al, {{.InputNumber "noisegate" "attack"}}
+    {{.Call "su_nonlinear_map"}}                ; attack level holding x
+    fsubp  st1, st0                             ; (level-attack) holding x
+    fldz                                        ; 0 level' holding x
+    fucomi  st0, st1                            ; limit level holding x
+    jbe     su_op_noisegate_leave               ;; if (limit <= level) -> jump
+    fxch                                        ; level (limit==level) holding x
+su_op_noisegate_leave:
+    fstp    st0                                 ; level holding x
+    fld1                                        ; 1 level holding x
+    fsub    st0, st1                            ; (1-level) level holding x
+    fstp    dword [{{.WRK}}]                    ; level holding x
+    fxch                                        ; holding level  x
+    fstp    dword [{{.WRK}}+4]                  ; level x
+{{- if and (.Stereo "noisegate") (not (.Mono "noisegate"))}}
+    fld     st0                                 ; and return the computed gain two times, ready for MULP STEREO
+{{- end}}
+    ret
+{{- end}}

--- a/vm/go_synth.go
+++ b/vm/go_synth.go
@@ -616,38 +616,32 @@ func (s *GoSynth) Render(buffer sointu.AudioBuffer, maxtime int) (samples int, r
 					unit.state[2+i] = b2*x - a2*y
 					stack[l-1-i] = y
 				}
-			case opNoisegate:
+			case opGate:
 				signal := stack[l-1] * stack[l-1]
 				if stereo {
-					signalR := stack[l-2] * stack[l-2]
-					if signal < signalR {
-						signal = signalR
-					}
+					signal += stack[l-2] * stack[l-2]
 				}
-				threshold := params[0] * params[0]
-				// unit.state takes inverse level, to be initialized at 1
-				level := 1 - unit.state[0]
+				threshold := params[3] * params[3]
+				level := unit.state[0]
 				holding := unit.state[1]
 				// attacking is delayed until "holding" did count down to 0
 				if signal > threshold {
 					holding = 1
-				} else if holding > 0 {
-					holding -= nonLinearMap(params[3])
-				}
-				if holding > 0 {
-					release := nonLinearMap(params[2])
+					release := nonLinearMap(params[0])
 					level += release
 					if level > 1 {
 						level = 1
 					}
-				} else {
-					attack := nonLinearMap(params[1])
+				}
+				holding -= nonLinearMap(params[1])
+				if holding < 0 {
+					attack := nonLinearMap(params[2])
 					level -= attack
 					if level < 0 {
 						level = 0
 					}
 				}
-				unit.state[0] = 1 - level
+				unit.state[0] = level
 				unit.state[1] = holding
 				// like the compressor, this does not directly multiply the factor
 				// but writes it onto the stack for the user to decide what to do

--- a/vm/go_synth.go
+++ b/vm/go_synth.go
@@ -616,6 +616,45 @@ func (s *GoSynth) Render(buffer sointu.AudioBuffer, maxtime int) (samples int, r
 					unit.state[2+i] = b2*x - a2*y
 					stack[l-1-i] = y
 				}
+			case opNoisegate:
+				signal := stack[l-1] * stack[l-1]
+				if stereo {
+					signalR := stack[l-2] * stack[l-2]
+					if signal < signalR {
+						signal = signalR
+					}
+				}
+				threshold := params[0] * params[0]
+				// unit.state takes inverse level, to be initialized at 1
+				level := 1 - unit.state[0]
+				holding := unit.state[1]
+				// attacking is delayed until "holding" did count down to 0
+				if signal > threshold {
+					holding = 1
+				} else if holding > 0 {
+					holding -= nonLinearMap(params[3])
+				}
+				if holding > 0 {
+					release := nonLinearMap(params[2])
+					level += release
+					if level > 1 {
+						level = 1
+					}
+				} else {
+					attack := nonLinearMap(params[1])
+					level -= attack
+					if level < 0 {
+						level = 0
+					}
+				}
+				unit.state[0] = 1 - level
+				unit.state[1] = holding
+				// like the compressor, this does not directly multiply the factor
+				// but writes it onto the stack for the user to decide what to do
+				stack = append(stack, level)
+				if stereo {
+					stack = append(stack, level)
+				}
 			case opSync:
 				break
 			default:

--- a/vm/opcodes.go
+++ b/vm/opcodes.go
@@ -15,15 +15,15 @@ const (
 	opEnvelope   = 11
 	opFilter     = 12
 	opGain       = 13
-	opHold       = 14
-	opIn         = 15
-	opInvgain    = 16
-	opLoadnote   = 17
-	opLoadval    = 18
-	opMul        = 19
-	opMulp       = 20
-	opNoise      = 21
-	opNoisegate  = 22
+	opGate       = 14
+	opHold       = 15
+	opIn         = 16
+	opInvgain    = 17
+	opLoadnote   = 18
+	opLoadval    = 19
+	opMul        = 20
+	opMulp       = 21
+	opNoise      = 22
 	opOscillator = 23
 	opOut        = 24
 	opOutaux     = 25
@@ -37,4 +37,4 @@ const (
 	opXch        = 33
 )
 
-var transformCounts = [...]int{0, 0, 1, 3, 0, 5, 1, 1, 4, 1, 5, 2, 1, 1, 0, 1, 0, 1, 0, 0, 2, 4, 6, 1, 2, 1, 0, 0, 0, 1, 0, 0, 0}
+var transformCounts = [...]int{0, 0, 1, 3, 0, 5, 1, 1, 4, 1, 5, 2, 1, 4, 1, 0, 1, 0, 1, 0, 0, 2, 6, 1, 2, 1, 0, 0, 0, 1, 0, 0, 0}

--- a/vm/opcodes.go
+++ b/vm/opcodes.go
@@ -23,17 +23,18 @@ const (
 	opMul        = 19
 	opMulp       = 20
 	opNoise      = 21
-	opOscillator = 22
-	opOut        = 23
-	opOutaux     = 24
-	opPan        = 25
-	opPop        = 26
-	opPush       = 27
-	opReceive    = 28
-	opSend       = 29
-	opSpeed      = 30
-	opSync       = 31
-	opXch        = 32
+	opNoisegate  = 22
+	opOscillator = 23
+	opOut        = 24
+	opOutaux     = 25
+	opPan        = 26
+	opPop        = 27
+	opPush       = 28
+	opReceive    = 29
+	opSend       = 30
+	opSpeed      = 31
+	opSync       = 32
+	opXch        = 33
 )
 
-var transformCounts = [...]int{0, 0, 1, 3, 0, 5, 1, 1, 4, 1, 5, 2, 1, 1, 0, 1, 0, 1, 0, 0, 2, 6, 1, 2, 1, 0, 0, 0, 1, 0, 0, 0}
+var transformCounts = [...]int{0, 0, 1, 3, 0, 5, 1, 1, 4, 1, 5, 2, 1, 1, 0, 1, 0, 1, 0, 0, 2, 4, 6, 1, 2, 1, 0, 0, 0, 1, 0, 0, 0}


### PR DESCRIPTION
1.5 years ago, I boasted about doing
https://github.com/vsariola/sointu/issues/109

now I finally did one. it has adjustable threshold (works on power / the squared signal), attack, release and hold times.

I was unsure whether that belongs under the [0.6.0] section in the changelog; and maybe we want some tests for that (it sounded like expected in my manual testing, in both synths), but I have no recollection about how to best add these here.